### PR TITLE
fix front-end build

### DIFF
--- a/multitenancy/web/ui/package.json
+++ b/multitenancy/web/ui/package.json
@@ -16,7 +16,7 @@
     "material-ui": "^0.9.2",
     "react": "^0.13.3",
     "react-router": "^0.13.3",
-    "react-tap-event-plugin": "^0.1.7",
+    "react-tap-event-plugin": "0.1.7",
     "rx": "^2.5.3",
     "superagent": "^1.2.0"
   },


### PR DESCRIPTION
fix react tap plugin version
`^1.0.7` would cause front-end build to fail as `1.0.8` brings breaking changes;
fixed by removing caret symbol (`^1.0.7 -> 1.0.7`)

Origin: this [discussion](https://groups.google.com/d/msg/z-manager/M2HR1MsCx84/fF0y9LQ0EgAJ) and [proposed solution](https://gist.github.com/aimran/aebee71d488b6d487cb0#file-readme-L33)

Test plan:
- `rm -rf node_modules`
- `npm install`
